### PR TITLE
Remove nonfunctioning xap, air okc apps from page

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,23 +40,6 @@
             <li><a href="https://github.com/MattSchroyer/buddy-cue">Go to the repo in GitHub</a></li>
           </ul>
         </div>
-	
-        <div class="project_card">
-          <a href="https://labs.exaptive.city/xap/b2b8a940-224e-11e8-8c1e-6d6c7ec5b4e7?version=0.10.1"><h2>Excel to 3D Terrain Application</h2></a>
-          <p><IMG SRC="./img/excel_to_terrain.png"></p>
-          <p>
-            This application will turn an Excel spreadsheet into a 3D terrain.
-            Each of the three dimensions of the terrain can be mapped to a dimension of the spreadsheet data.
-            Various qualities of the terrain, such as color, resolution, and smoothness can be set.
-            Additionally, the user can place "pins" in the terrain, which can identify and display 
-            the underlying data from spreadsheet. On load, generates initial terrain with the "MTCars" dataset,
-            which is a set of car specifications from the 1970s. Built as a "xap" (application) in the Exaptive Studio,
-            featuring Three.js and Semantic UI libraries.
-          </p>
-          <ul>
-            <li><a href="https://labs.exaptive.city/xap/b2b8a940-224e-11e8-8c1e-6d6c7ec5b4e7?version=0.10.1">Go to the Xap</a></li>
-          </ul>
-        </div>
 
         <div class="project_card">
           <a href="http://mattschroyer.github.io/traffic"><h2>Traffic Dataviz</h2></a>
@@ -110,16 +93,6 @@
           <ul>
             <li><a href="https://github.com/mattschroyer/roomfinder3d">Go to the repo in GitHub</a></li>
             <li><a href="http://mattschroyer.github.io/roomfinder3d">Go to the roomfinder</a></li>
-          </ul>
-        </div>
-        
-        <div class="project_card">
-          <a href="http://mattschroyer.github.io/airOKC"><h2>Air OKC Scrape-n-Viz</h2></a>
-          <p><IMG SRC="./img/air_okc_screenshot.jpg"></p>
-          <p>Building on the success of the <a href="http://dustduino.org/">DustDuino</a> <a href="http://www.mentalmunition.com/search/label/dustduino">IoT initiative</a>, AirOKC is a "serverless" scraping and visualization platform. Ozone readings are scraped from the Oklahoma Department of Environmental Quality (ODEQ) monitor 401090033 on an hourly basis. The back-end is a Google Sheet fed via a scraping script. On the front-end, Tabletop reads the sheets, while d3 handles the viz. Please allow the chart several seconds to load; Google Sheets is not the quickest data host.</p>
-          <ul>
-            <li><a href="https://github.com/mattschroyer/airokc">Go to the repo in GitHub</a></li>
-            <li><a href="http://mattschroyer.github.io/airOKC">Go to Air OKC</a></li>
           </ul>
         </div>
         


### PR DESCRIPTION
Removing the cards for Xap and OKC air apps from the page, because they are no longer functional and I don't wish to maintain them.